### PR TITLE
Rewrite to use new QuickSettings API in Gnome43

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Keyboard Backlight slider for gnome
 
-Set the keyboard backlight brightness with a slider in gnome shell's system menu.
+Set the keyboard backlight brightness with a slider in gnome shell's "Quick Settings" menu.
 
 <table>
 <td>
@@ -13,7 +13,11 @@ This extension adds a third slider below the sound and brightness sliders in the
 
 ## Changelog
 
+### v6
+
+- Rewrite to support Gnome 43 via QuickSettings API
+
 ### v5
 
- - Fixed compatibility with ubuntu
- - better logging
+- Fixed compatibility with ubuntu
+- better logging

--- a/extension.js
+++ b/extension.js
@@ -19,27 +19,12 @@
 /* exported init */
 "use strict";
 
-const { Gio, GLib, GObject, St } = imports.gi;
+const {Gio, GObject} = imports.gi;
 
-const PanelMenu = imports.ui.panelMenu;
-const PopupMenu = imports.ui.popupMenu;
-const Slider = imports.ui.slider;
-const Main = imports.ui.main;
+const QuickSettings = imports.ui.quickSettings;
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Gettext = imports.gettext;
-const Domain = Gettext.domain(Me.metadata.uuid);
-const _ = Domain.gettext;
-
-function setTimeout(func, delay, ...args) {
-    return GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
-        func(...args);
-        return GLib.SOURCE_REMOVE;
-    });
-};
-
-function clearTimeout(timeout) { GLib.source_remove(timeout); };
+// This is the live instance of the Quick Settings menu
+const QuickSettingsMenu = imports.ui.main.panel.statusArea.quickSettings;
 
 class KbdBrightnessProxy {
     constructor(callback) {
@@ -82,88 +67,69 @@ class KbdBrightnessProxy {
     }
 }
 
-const Indicator = GObject.registerClass(
-    class Indicator extends PanelMenu.SystemIndicator {
+
+const FeatureIndicator = GObject.registerClass(
+    class FeatureIndicator extends QuickSettings.SystemIndicator {
         _init() {
             super._init();
-            this._proxy = new KbdBrightnessProxy((proxy, error) => {
-                if (error) throw error;
-                proxy.connectSignal('BrightnessChanged', this._sync.bind(this));
-                this._sync();
+
+            // Create the slider and associate it with the indicator, being sure to
+            // destroy it along with the indicator
+            this.quickSettingsItems.push(new FeatureSlider());
+
+            this.connect('destroy', () => {
+                this.quickSettingsItems.forEach(item => item.destroy());
             });
 
-            this._item = new PopupMenu.PopupBaseMenuItem({ activate: false });
-            this.menu.addMenuItem(this._item);
+            // Add the indicator to the panel
+            QuickSettingsMenu._indicators.add_child(this);
 
-            this._slider = new Slider.Slider(0);
-            this._sliderChangedId = this._slider.connect('notify::value',
-                this._sliderChanged.bind(this));
-            this._slider.accessible_name = _("Keyboard brightness");
-
-            let icon = new St.Icon({
-                icon_name: 'keyboard-brightness-symbolic',
-                style_class: 'popup-menu-icon'
-            });
-            this._item.add(icon);
-            this._item.add_child(this._slider);
-            this._item.connect('button-press-event', (actor, event) => {
-                return this._slider.startDragging(event);
-            });
-            this._item.connect('key-press-event', (actor, event) => {
-                return this._slider.emit('key-press-event', event);
-            });
-            this._item.connect('scroll-event', (actor, event) => {
-                return this._slider.emit('scroll-event', event);
-            });
-            this.lastChange = Date.now();
-            this.changeSliderTimeout = null;
-        }
-
-        _sliderChanged() {
-            this.lastChange = Date.now();
-            this._proxy.Brightness = this._slider.value;
-        }
-
-        _changeSlider(value) {
-            this._slider.block_signal_handler(this._sliderChangedId);
-            this._slider.value = value;
-            this._slider.unblock_signal_handler(this._sliderChangedId);
-        }
-
-        _sync() {
-            let visible = this._proxy.Brightness >= 0;
-            this._item.visible = visible;
-            if (visible) {
-                if (this.changeSliderTimeout) clearTimeout(this.changeSliderTimeout);
-                let dt = this.lastChange + 1000 - Date.now();
-                if (dt < 0) dt = 0;
-                this.changeSliderTimeout = setTimeout(_ => {
-                    this.changeSliderTimeout = null;
-                    this._changeSlider(this._proxy.Brightness)
-                }, dt);
-            }
-        }
-
-        destroy() {
-            if (this.changeSliderTimeout) clearTimeout(this.changeSliderTimeout);
-            this.menu.destroy();
-            super.destroy();
+            // Add the slider to the menu, passing `2` as the second
+            // argument to ensure the slider spans both columns of the menu
+            QuickSettingsMenu._addItems(this.quickSettingsItems, 2);
         }
     });
 
-var _indicator;
+const FeatureSlider = GObject.registerClass(
+    class FeatureSlider extends QuickSettings.QuickSlider {
+        _init() {
+            super._init({
+                iconName: 'keyboard-brightness-symbolic',
+            });
+
+            this._sliderChangedId = this.slider.connect('notify::value',
+                this._onSliderChanged.bind(this));
+
+            this.slider.accessible_name = 'Keyboard Brightness';
+
+            // create instance of KbpBrightnessProxy
+            this._proxy = new KbdBrightnessProxy((proxy, error) => {
+                if (error) throw error;
+                // proxy.connectSignal('BrightnessChanged', this._sync.bind(this));
+                // this._sync();
+            });
+        }
+
+        _onSliderChanged() {
+            this._proxy.Brightness = this.slider.value;
+        }
+    });
+
+class Extension {
+    constructor() {
+        this._indicator = null;
+    }
+
+    enable() {
+        this._indicator = new FeatureIndicator();
+    }
+
+    disable() {
+        this._indicator.destroy();
+        this._indicator = null;
+    }
+}
 
 function init() {
-    log(`initializing ${Me.metadata.name}`);
-    ExtensionUtils.initTranslations(Me.metadata.uuid);
-}
-
-function enable() {
-    _indicator = new Indicator();
-    Main.panel.statusArea.aggregateMenu.menu.addMenuItem(this._indicator.menu, 2);
-}
-
-function disable() {
-    _indicator.destroy();
-    _indicator = null;
+    return new Extension();
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,10 @@
 {
-  "version": 5,
+  "version": 6,
   "name": "Keyboard Backlight Slider",
-  "description": "Allow setting the keyboard backlight brightness with a slider in the main menu",
+  "description": "Allow setting the keyboard backlight brightness with a slider in Quick Settings",
   "uuid": "keyboard-backlight-menu@ophir.dev",
   "url": "https://github.com/lovasoa/gnome-keyboard-backlight-menu",
   "shell-version": [
-    "40",
-    "41",
-    "42"
+    "43"
   ]
 }


### PR DESCRIPTION
The aggregateMenu which was previously in use is no longer supported:

https://gjs.guide/extensions/upgrading/gnome-shell-43.html#quick-settings

Fixes #7

---

@lovasoa I could use your help to get this PR fixed up to be mergeable. To be honest I have no idea what I am doing; the documentation on gnome-shell extension development seems pretty thin on the ground and you have to connect a lot of dots yourself (there is no complete example). The last time I wrote any JavaScript, jQuery was the latest and greatest! 😅

I basically started from scratch so a lot of stuff has gone missing (the `_sync()` function etc) and I have no clue what any of it does. This plugin works on my machine however! Perhaps some of it is not needed with the new QuickSettings API? 

Let me know what you think and how we should proceed.

Thanks,
Aaron